### PR TITLE
Update to libsass v0.22.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "libsass" %}
-{% set version = "0.21.0" %}
+{% set version = "0.22.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,13 +7,12 @@ package:
 
 source:
   url: https://github.com/sass/{{ name }}-python/releases/download/{{ version }}/{{ name }}-{{ version }}.tar.gz
-  sha256: d5ba529d9ce668be9380563279f3ffe988f27bc5b299c5a28453df2e0b0fbaf2
+  sha256: 3ab5ad18e47db560f4f0c09e3d28cf3bb1a44711257488ac2adad69f4f7f8425
 
 build:
-  number: 2
+  number: 0
   entry_points:
     - pysassc = pysassc:main
-    - sassc = sassc:main
   script: {{ PYTHON }} -m pip install . -vv
   skip: true  # [win and py2k]
 


### PR DESCRIPTION
Hi, this removes the `sassc` entrypoint and updates the recipe to libsass v0.22.0

